### PR TITLE
Fix network request path conflicts with base path

### DIFF
--- a/src/Http/Api/Endpoints/AccountEndpoints.php
+++ b/src/Http/Api/Endpoints/AccountEndpoints.php
@@ -21,7 +21,7 @@ class AccountEndpoints
     public function getByAddress(string $address, array $params = []): Account
     {
         return Account::fromApiResponse(
-            $this->client->request('GET', "/accounts/{$address}", [
+            $this->client->request('GET', "accounts/{$address}", [
                 'query' => $params,
             ]),
         );
@@ -30,7 +30,7 @@ class AccountEndpoints
     public function getNfts(string $address, array $params = []): Collection
     {
         return Nft::fromApiResponse(
-            $this->client->request('GET', "/accounts/{$address}/nfts", [
+            $this->client->request('GET', "accounts/{$address}/nfts", [
                 'query' => $params,
             ]),
             collection: true,
@@ -40,7 +40,7 @@ class AccountEndpoints
     public function getTokens(string $address, array $params = []): Collection
     {
         return TokenDetailedWithBalance::fromApiResponse(
-            $this->client->request('GET', "/accounts/{$address}/tokens", [
+            $this->client->request('GET', "accounts/{$address}/tokens", [
                 'query' => $params,
             ]),
             collection: true,
@@ -50,7 +50,7 @@ class AccountEndpoints
     public function getToken(string $address, string $token, array $params = []): TokenDetailedWithBalance
     {
         return TokenDetailedWithBalance::fromApiResponse(
-            $this->client->request('GET', "/accounts/{$address}/tokens/{$token}", [
+            $this->client->request('GET', "accounts/{$address}/tokens/{$token}", [
                 'query' => $params,
             ]),
         );
@@ -59,7 +59,7 @@ class AccountEndpoints
     public function getCollections(string $address, array $params = []): Collection
     {
         return NftCollectionAccount::fromApiResponse(
-            $this->client->request('GET', "/accounts/{$address}/collections", [
+            $this->client->request('GET', "accounts/{$address}/collections", [
                 'query' => $params,
             ]),
             collection: true,
@@ -69,7 +69,7 @@ class AccountEndpoints
     public function getCollection(string $address, string $collection, array $params = []): NftCollectionAccount
     {
         return NftCollectionAccount::fromApiResponse(
-            $this->client->request('GET', "/accounts/{$address}/collections/{$collection}", [
+            $this->client->request('GET', "accounts/{$address}/collections/{$collection}", [
                 'query' => $params,
             ]),
         );
@@ -78,7 +78,7 @@ class AccountEndpoints
     public function getRolesCollections(string $address, array $params = []): Collection
     {
         return NftCollectionRole::fromApiResponse(
-            $this->client->request('GET', "/accounts/{$address}/roles/collections", [
+            $this->client->request('GET', "accounts/{$address}/roles/collections", [
                 'query' => $params,
             ]),
             collection: true,
@@ -88,7 +88,7 @@ class AccountEndpoints
     public function getRolesCollection(string $address, string $collection, array $params = []): NftCollectionRole
     {
         return NftCollectionRole::fromApiResponse(
-            $this->client->request('GET', "/accounts/{$address}/roles/collections/{$collection}", [
+            $this->client->request('GET', "accounts/{$address}/roles/collections/{$collection}", [
                 'query' => $params,
             ]),
         );
@@ -97,7 +97,7 @@ class AccountEndpoints
     public function getTransactions(string $address, array $params = []): Collection
     {
         return Transaction::fromApiResponse(
-            $this->client->request('GET', "/accounts/{$address}/transactions", [
+            $this->client->request('GET', "accounts/{$address}/transactions", [
                 'query' => $params,
             ]),
             collection: true,

--- a/src/Http/Api/Endpoints/BlockEndpoints.php
+++ b/src/Http/Api/Endpoints/BlockEndpoints.php
@@ -16,7 +16,7 @@ final class BlockEndpoints
     public function getBlocks(array $params = []): Collection
     {
         return Block::fromApiResponse(
-            $this->client->request('GET', "/blocks", [
+            $this->client->request('GET', "blocks", [
                 'query' => $params,
             ]),
             collection: true,

--- a/src/Http/Api/Endpoints/CollectionEndpoints.php
+++ b/src/Http/Api/Endpoints/CollectionEndpoints.php
@@ -18,7 +18,7 @@ class CollectionEndpoints
     public function getById(string $identifier, array $params = []): NftCollection
     {
         return NftCollection::fromApiResponse(
-            $this->client->request('GET', "/collections/{$identifier}", [
+            $this->client->request('GET', "collections/{$identifier}", [
                 'query' => $params,
             ]),
         );
@@ -27,7 +27,7 @@ class CollectionEndpoints
     public function getNftsById(string $identifier, array $params = []): Collection
     {
         return Nft::fromApiResponse(
-            $this->client->request('GET', "/collections/{$identifier}/nfts", [
+            $this->client->request('GET', "collections/{$identifier}/nfts", [
                 'query' => $params,
             ]),
             collection: true,
@@ -37,7 +37,7 @@ class CollectionEndpoints
     public function getAccounts(string $tokenId, array $params = []): Collection
     {
         return CollectionAccount::fromApiResponse(
-            $this->client->request('GET', "/collections/{$tokenId}/accounts", [
+            $this->client->request('GET', "collections/{$tokenId}/accounts", [
                 'query' => $params,
             ]),
             collection: true,

--- a/src/Http/Api/Endpoints/NftEndpoints.php
+++ b/src/Http/Api/Endpoints/NftEndpoints.php
@@ -17,7 +17,7 @@ class NftEndpoints
     public function getById(string $identifier, array $params = []): Nft
     {
         return Nft::fromApiResponse(
-            $this->client->request('GET', "/nfts/{$identifier}", [
+            $this->client->request('GET', "nfts/{$identifier}", [
                 'query' => $params,
             ]),
         );
@@ -26,7 +26,7 @@ class NftEndpoints
     public function getAccounts(string $identifier, array $params = []): Collection
     {
         return NftOwner::fromApiResponse(
-            $this->client->request('GET', "/nfts/{$identifier}/accounts", [
+            $this->client->request('GET', "nfts/{$identifier}/accounts", [
                 'query' => $params,
             ]),
             collection: true,

--- a/src/Http/Api/Endpoints/TokenEndpoints.php
+++ b/src/Http/Api/Endpoints/TokenEndpoints.php
@@ -19,7 +19,7 @@ class TokenEndpoints
     public function getById(string $tokenId, array $params = []): TokenDetailed
     {
         return TokenDetailed::fromApiResponse(
-            $this->client->request('GET', "/tokens/{$tokenId}", [
+            $this->client->request('GET', "tokens/{$tokenId}", [
                 'query' => $params,
             ]),
         );
@@ -28,7 +28,7 @@ class TokenEndpoints
     public function getTokens(array $params = []): Collection
     {
         return TokenDetailed::fromApiResponse(
-            $this->client->request('GET', "/tokens", [
+            $this->client->request('GET', "tokens", [
                 'query' => $params,
             ]),
             collection: true,
@@ -38,7 +38,7 @@ class TokenEndpoints
     public function getAccounts(string $tokenId, array $params = []): Collection
     {
         return TokenAccount::fromApiResponse(
-            $this->client->request('GET', "/tokens/{$tokenId}/accounts", [
+            $this->client->request('GET', "tokens/{$tokenId}/accounts", [
                 'query' => $params,
             ]),
             collection: true,
@@ -47,7 +47,7 @@ class TokenEndpoints
 
     public function getAccountsCount(string $tokenId, array $params = []): int
     {
-        return (int) $this->client->request('GET', "/tokens/{$tokenId}/accounts/count", [
+        return (int) $this->client->request('GET', "tokens/{$tokenId}/accounts/count", [
             'query' => $params,
         ])
             ->getBody()
@@ -57,7 +57,7 @@ class TokenEndpoints
     public function getTransactions(string $tokenId, array $params = []): Collection
     {
         return Transaction::fromApiResponse(
-            $this->client->request('GET', "/tokens/{$tokenId}/transactions", [
+            $this->client->request('GET', "tokens/{$tokenId}/transactions", [
                 'query' => $params,
             ]),
             collection: true,
@@ -67,7 +67,7 @@ class TokenEndpoints
     public function getRoles(string $tokenId, array $params = []): Collection
     {
         return TokenAddressRoles::fromApiResponse(
-            $this->client->request('GET', "/tokens/{$tokenId}/roles", [
+            $this->client->request('GET', "tokens/{$tokenId}/roles", [
                 'query' => $params,
             ]),
             collection: true,

--- a/src/Http/Api/Endpoints/TransactionEndpoints.php
+++ b/src/Http/Api/Endpoints/TransactionEndpoints.php
@@ -17,7 +17,7 @@ class TransactionEndpoints
     public function getByHash(string $txHash, array $params = []): TransactionDetailed
     {
         return TransactionDetailed::fromApiResponse(
-            $this->client->request('GET', "/transactions/{$txHash}", [
+            $this->client->request('GET', "transactions/{$txHash}", [
                 'query' => $params,
             ]),
         );
@@ -26,7 +26,7 @@ class TransactionEndpoints
     public function send(Transaction $tx): TransactionSendResult
     {
         return TransactionSendResult::fromApiResponse(
-            $this->client->request('POST', "/transactions", [
+            $this->client->request('POST', "transactions", [
                 'json' => $tx->toSendable(),
             ]),
         );

--- a/src/Http/Api/Endpoints/VmEndpoints.php
+++ b/src/Http/Api/Endpoints/VmEndpoints.php
@@ -23,7 +23,7 @@ class VmEndpoints
             : $args;
 
         return VmQueryResult::fromApiResponse(
-            $this->client->request('POST', "/vm-values/query", [
+            $this->client->request('POST', "vm-values/query", [
                 'json' => [
                     'scAddress' => $contractAddress,
                     'funcName' => $func,
@@ -42,7 +42,7 @@ class VmEndpoints
             : $args;
 
         return VmHexResult::fromApiResponse(
-            $this->client->request('POST', "/vm-values/hex", [
+            $this->client->request('POST', "vm-values/hex", [
                 'json' => [
                     'scAddress' => $contractAddress,
                     'funcName' => $func,
@@ -61,7 +61,7 @@ class VmEndpoints
             : $args;
 
         return VmStringResult::fromApiResponse(
-            $this->client->request('POST', "/vm-values/string", [
+            $this->client->request('POST', "vm-values/string", [
                 'json' => [
                     'scAddress' => $contractAddress,
                     'funcName' => $func,
@@ -80,7 +80,7 @@ class VmEndpoints
             : $args;
 
         return VmIntResult::fromApiResponse(
-            $this->client->request('POST', "/vm-values/int", [
+            $this->client->request('POST', "vm-values/int", [
                 'json' => [
                     'scAddress' => $contractAddress,
                     'funcName' => $func,

--- a/src/Http/ClientFactory.php
+++ b/src/Http/ClientFactory.php
@@ -8,14 +8,13 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use Psr\Http\Client\RequestExceptionInterface;
-use Psr\Http\Message\ResponseInterface;
 
 class ClientFactory
 {
     public static function create(string $baseUrl, array $options = []): ClientInterface
     {
         if (! isset($options['base_uri'])) {
-            $options['base_uri'] = $baseUrl;
+            $options['base_uri'] = rtrim($baseUrl, '/') . '/';
         }
 
         $options['headers'] = [


### PR DESCRIPTION
Using absolute paths overrides the paths defined in the base URI.

Specifically, this does not allow using for example Blast API which uses this format as base URI: `https://multiversx-api.blastapi.io/<token>` – `/<token>` is ignored in this case

Using relative request paths fixes this.