### PR TITLE
Add handling of empty event logs for TransactionDetailed

### DIFF
--- a/src/Http/Entities/TransactionDetailed.php
+++ b/src/Http/Entities/TransactionDetailed.php
@@ -54,10 +54,11 @@ final class TransactionDetailed implements IEntity
 
     public function getAllEvents(): Collection
     {
-        return $this->logs->events
+        return $this->logs
+            ?->events
             ->concat($this->results->map(fn (SmartContractResult $result) => $result->logs?->events))
             ->flatten()
-            ->filter();
+            ->filter() ?? new Collection;
     }
 
     public function hasContractError(): bool

--- a/tests/Http/Api/TransactionsTest.php
+++ b/tests/Http/Api/TransactionsTest.php
@@ -23,6 +23,18 @@ it('getAllEvents - returns all events of a transaction', function () {
         ->toHaveCount(76);
 });
 
+it('getAllEvents - returns empty when zero log events', function () {
+    $client = createMockedHttpClientWithResponse('transactions/tx.json');
+
+    $actual = (new TransactionEndpoints($client))
+        ->getByHash('01b94cb36f027bab9391414971c7feb348755c53f8ea27f19c18fb82db35ea7d');
+
+    $actual->logs = null;
+
+    expect($actual->getAllEvents())
+        ->toBeEmpty();
+});
+
 it('hasContractError - returns true when contract errors', function () {
     $client = createMockedHttpClientWithResponse('transactions/tx-contract-error.json');
 


### PR DESCRIPTION
Currently throws with `Attempt to read property "events" on null` when empty.